### PR TITLE
Changes to make it more clear for the ansible installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ end
 <hr/>
 ##### Ansible Playbook - CloudHealth Agent Installation Helper - BETA 
 <hr/>
- 
+
+Replace unique-registration-code with your unique code. You can get the code from the agent configuration page https://apps.cloudhealthtech.com/agent_settings/edit
+
+Note: Do not use the API Key from https://apps.cloudhealthtech.com/profile
 
 ```
 ---


### PR DESCRIPTION
This is for the ticket "REQUEST #4388 CLOUD HEALTH AGENT INSTALLATION THROUGH ANSIBLE"

The cloudinit section has the url to get the api access key but the ansible installation doesn’t. I think that is where the confusion comes from.

if you have read the cloudinit section then you would probably be fine but since if you are using ansible installation, people would skip reading through that section and got the api key from the wrong place
